### PR TITLE
resync ombi media after cleaning

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,14 @@ import 'dotenv/config'
 
 import cleanMovies from './lib/movies/index.js'
 import cleanTV from './lib/tv/index.js'
+import { resyncOmbiMedia } from './lib/apis/ombi.js'
 
 async function run() {
  await cleanMovies()
- await cleanTV()   
+ await cleanTV()
+
+ // Media resync applies to both movies and TV.
+ await resyncOmbiMedia()
 }
 
 run()

--- a/lib/apis/ombi.js
+++ b/lib/apis/ombi.js
@@ -31,4 +31,10 @@ export function markOmbiMovieUnavailable(movieId) {
   })
 }
 
+// Resync Ombi DB with media server so any deleted
+// requests can be re-requested.
+export function resyncOmbiMedia() {
+  return ombiFetch('/api/v1/Job/clearmediaserverdata', 'POST')
+}
+
 export default ombiFetch


### PR DESCRIPTION
triggers a resync of Ombi media so that things can be re-requested if they are deleted